### PR TITLE
Add updates for newer esphome

### DIFF
--- a/ESPHome/bm6.h
+++ b/ESPHome/bm6.h
@@ -1,1 +1,2 @@
+#define MBEDTLS_CONFIG_FILE "mbedtls/esp_config.h"
 #include "mbedtls/aes.h"

--- a/ESPHome/bm6.yaml
+++ b/ESPHome/bm6.yaml
@@ -4,6 +4,9 @@
 esphome:
   includes:
     - "bm6.h"
+  platformio_options: 
+    build_flags: 
+      - '-DMBEDTLS_CONFIG_FILE="\"mbedtls/esp_config.h\""'
 
 esp32:
   board: esp32dev


### PR DESCRIPTION
First off - thanks for putting this together! I'm really happy with being able to use it. 

I ran into some errors with `mbedtls/aes.h` as is with ESPHome `2026.1.5`.

I found [this thread](https://www.reddit.com/r/Esphome/comments/1d16mpg/comment/m1npjik/) that described some fixes, and luckily the most recent one (as of a few hours ago!) worked. 

This may break older versions of ESPHome - I haven't checked. 